### PR TITLE
feat: header nav mobile menu transition

### DIFF
--- a/src/components/HeaderNav/HeaderNav.css
+++ b/src/components/HeaderNav/HeaderNav.css
@@ -39,6 +39,7 @@
   padding: 0;
   gap: 14px;
   background: transparent;
+  /* visibility: hidden; */
 }
 
 .header-nav__social {
@@ -98,6 +99,15 @@
     padding: 20px 0 20px 0;
     box-sizing: content-box;
     gap: 18px;
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 0s linear .5s, opacity .5s linear;
+  }
+
+  .header-nav__links_mobile-menu {
+    visibility: visible;
+    opacity: 1;
+    transition-delay: 0s;
   }
 
   .header-nav__links_theme_light {

--- a/src/components/HeaderNav/HeaderNav.js
+++ b/src/components/HeaderNav/HeaderNav.js
@@ -7,9 +7,11 @@ import { screenSizes, lightModeStart } from '../../utils/constants';
 
 function HeaderNav({ windowInnerWidth, onResize, isMobileMenuOpen, onMenuIconClick, windowScrollY, onScrollY }) {
   const [isScrolling, setIsScrolling] = useState(false);
+
   useEffect(() => {
     window.addEventListener('resize', onResize);
   });
+
   useEffect(() => {
     let scrollingTimer;
     window.addEventListener(
@@ -35,14 +37,38 @@ function HeaderNav({ windowInnerWidth, onResize, isMobileMenuOpen, onMenuIconCli
       <a className={`header-nav__brand ${isHeaderNavLight ? 'dark-text' : ''}`} href="/">
         {brandTitle}
       </a>
-      {(!isMobile || isMobileMenuOpen) && (
+      {/* <ul
+        className={`header-nav__links ${isHeaderNavLight ? 'header-nav__links_theme_light' : ''}  ${
+          isMobileMenuOpen ? 'header-nav__links_mobile-menu' : ''
+        }
+            }`}
+      >
+        {links.map((link) => (
+          <NavLink htmlId={link.htmlId} title={link.title} key={link.id} isHeaderNavLight={isHeaderNavLight} />
+        ))}
+      </ul> */}
+      {!isMobile ? (
         <>
-          <ul className={`header-nav__links ${isHeaderNavLight ? 'header-nav__links_theme_light' : ''}`}>
+          <ul
+            className={`header-nav__links ${isHeaderNavLight ? 'header-nav__links_theme_light' : ''} ${
+              isMobileMenuOpen ? 'header-nav__links_mobile-menu' : ''
+            }`}
+          >
             {links.map((link) => (
               <NavLink htmlId={link.htmlId} title={link.title} key={link.id} isHeaderNavLight={isHeaderNavLight} />
             ))}
           </ul>
         </>
+      ) : (
+        <ul
+          className={`header-nav__links ${isHeaderNavLight ? 'header-nav__links_theme_light' : ''} ${
+            isMobileMenuOpen ? 'header-nav__links_mobile-menu' : ''
+          }`}
+        >
+          {links.map((link) => (
+            <NavLink htmlId={link.htmlId} title={link.title} key={link.id} isHeaderNavLight={isHeaderNavLight} />
+          ))}
+        </ul>
       )}
       <a
         className={`header-nav__social ${isMobile ? 'header-nav__social_mobile' : ''} ${


### PR DESCRIPTION
I've managed to make a simple smooth transition for the mobile menu. Problem is I needed to use a weird construction where I use a ternary operator that renders the same exact element in both branches. If I ditch the ternary the transition occurs when switching from 768 to 767. I've spent long enough trying to make it work, so if anyone wants to take a look let me know.

If we don't have any other ideas I think I'd just refactor the duplicated markup into a separate component:

```{!isMobile ? <NavLinks mobile={false} /> : <NavLinks mobile={true} />}```

to clean things up a bit.