### PR TITLE
fix: center image in product carousel on mobile devices

### DIFF
--- a/src/components/Carousel/Carousel.css
+++ b/src/components/Carousel/Carousel.css
@@ -93,18 +93,21 @@
 
 @media screen and (max-width: 670px) {
     .carousel {
-        width: 220px;
+        width: 280px;
         height: 418px;
         position: absolute;
         top: 10px;
         left: 50%;
         transform: translate(-50%, 0);
         display: flex;
+        padding: 0;
+        justify-content: center;
     }
 
     .carousel-item {
         padding: 0 0 36px;
-        justify-items: center;
+        display: flex;
+        justify-content: center;
     }
     
     .carousel-item__image {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37159177/113370769-b76db400-9332-11eb-92a7-6b65b2cfcbe8.png)
